### PR TITLE
I've integrated the Ollama Phi model and provided setup guidance for …

### DIFF
--- a/test/test-llm.sh
+++ b/test/test-llm.sh
@@ -3,7 +3,7 @@
 time curl http://localhost:8002/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "gpt-3.5-turbo",
+    "model": "phi",
     "messages": [
       {
         "role": "system",

--- a/voicechat2.py
+++ b/voicechat2.py
@@ -22,6 +22,7 @@ from mutagen.oggopus import OggOpus
 # External endpoints
 SRT_ENDPOINT = os.getenv("SRT_ENDPOINT", "http://localhost:8001/inference")
 LLM_ENDPOINT = os.getenv("LLM_ENDPOINT", "http://localhost:8002/v1/chat/completions")
+LLM_MODEL_NAME = os.getenv("LLM_MODEL_NAME", "phi")
 TTS_ENDPOINT = os.getenv("TTS_ENDPOINT", "http://localhost:8003/tts")
 
 logging.basicConfig(level=logging.DEBUG)
@@ -250,7 +251,7 @@ async def generate_llm_response(websocket, session_id, text):
         
         async with aiohttp.ClientSession() as session:
             async with session.post(LLM_ENDPOINT, json={
-                "model": "gpt-3.5-turbo",
+                "model": LLM_MODEL_NAME,
                 "messages": conversation + [{"role": "user", "content": text}],
                 "stream": True
             }) as response:


### PR DESCRIPTION
…you.

- I modified `voicechat2.py` to use the Ollama Phi model via `LLM_ENDPOINT` and new `LLM_MODEL_NAME` environment variables. The `LLM_MODEL_NAME` defaults to 'phi'.
- I updated `test/test-llm.sh` to use 'phi' as the default model for testing.
- I've provided comprehensive instructions for setting up and running the application with Ollama, including managing dependencies and the various server components (SRT, TTS, and the main app).
- I also clarified that a proxy server is generally not required for a local Ollama setup.